### PR TITLE
Fixed missing identifier quote characters

### DIFF
--- a/Core/Database/Mysql.php
+++ b/Core/Database/Mysql.php
@@ -53,7 +53,7 @@ class Mysql extends \Flake\Core\Database {
 	public function tables() {
 		$aTables = array();
 		
-		$sSql = "SHOW TABLES FROM " . $this->sDbName;
+		$sSql = "SHOW TABLES FROM `" . $this->sDbName . "`";
 		$oStmt = $this->query($sSql);
 		
 		while(($aRs = $oStmt->fetch()) !== FALSE) {


### PR DESCRIPTION
Mysql->tables() threw an error with database names containing "special" characters like "-".
