### PR TITLE
Allow override for PROJECT_PATH_DOCUMENTROOT

### DIFF
--- a/Framework.php
+++ b/Framework.php
@@ -118,8 +118,11 @@ class Framework extends \Flake\Core\Framework {
 
 		require_once(PROJECT_PATH_CORE . "Distrib.php");
 
+		# Include Flake Framework config
+		require_once(FLAKE_PATH_ROOT . "config.php");
+
 		if(PROJECT_PACKAGE === "regular") {
-			define("PROJECT_PATH_DOCUMENTROOT", PROJECT_PATH_ROOT . "html/");
+			define("PROJECT_PATH_DOCUMENTROOT", PROJECT_PATH_ROOT . FLAKE_DOCUMENTROOT_FOLDER . "/");
 		} elseif(PROJECT_PACKAGE === "flat") {
 			define("PROJECT_PATH_DOCUMENTROOT", PROJECT_PATH_ROOT);
 		} else {
@@ -147,9 +150,6 @@ class Framework extends \Flake\Core\Framework {
 		
 		require_once(FLAKE_PATH_ROOT . 'Util/Twig/lib/Twig/Autoloader.php');
 		\Twig_Autoloader::register();
-
-		# Include Flake Framework config
-		require_once(FLAKE_PATH_ROOT . "config.php");
 
 		# Determine Router class
 		$GLOBALS["ROUTER"] = \Flake\Util\Tools::router();

--- a/config.php
+++ b/config.php
@@ -35,3 +35,15 @@ if(defined("PROJECT_TIMEZONE")) {
 } else {
 	define("FLAKE_TIMEZONE", "Europe/Paris");
 }
+
+/**
+ * The constant PROJECT_DOCUMENTROOT_FOLDER allows the project to 
+ * define a folder, relative to the PROJECT_PATH_ROOT, which will 
+ * be used instead of the default "html" folder when constructing 
+ * PROJECT_PATH_DOCUMENTROOT.
+ */
+if(defined("PROJECT_DOCUMENTROOT_FOLDER")) {
+	define("FLAKE_DOCUMENTROOT_FOLDER", PROJECT_DOCUMENTROOT_FOLDER);
+} else {
+	define("FLAKE_DOCUMENTROOT_FOLDER", 'html');
+}


### PR DESCRIPTION
The new constant PROJECT_DOCUMENTROOT_FOLDER allows the project to define a folder, relative to the PROJECT_PATH_ROOT, which will be used instead of the default "html" folder when constructing PROJECT_PATH_DOCUMENTROOT.